### PR TITLE
Drop CL-HEREDOC-SYSTEM package

### DIFF
--- a/cl-heredoc-test.asd
+++ b/cl-heredoc-test.asd
@@ -16,11 +16,6 @@
 
 (in-package :cl-user)
 
-(defpackage :cl-heredoc-test-system
-  (:use :cl :asdf))
-
-(in-package :cl-heredoc-test-system)
-
 (asdf:defsystem :cl-heredoc-test
                 :description "cl-heredoc test package."
                 :version "0.0.1"

--- a/cl-heredoc.asd
+++ b/cl-heredoc.asd
@@ -16,11 +16,6 @@
 
 (in-package :cl-user)
 
-(defpackage :cl-heredoc-system
-  (:use :cl :asdf))
-
-(in-package :cl-heredoc-system)
-
 (asdf:defsystem :cl-heredoc
                 :description "Common Lisp reader heredoc dispatcher"
                 :version "0.1.0"

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -14,7 +14,7 @@
 ;;;; You should have received a copy of the GNU General Public License
 ;;;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(in-package :cl-heredoc-system)
+(in-package :cl-user)
 
 (defpackage :cl-heredoc
   (:use :cl)

--- a/test/package.lisp
+++ b/test/package.lisp
@@ -14,7 +14,7 @@
 ;;;; You should have received a copy of the GNU General Public License
 ;;;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-(in-package :cl-heredoc-test-system)
+(in-package :cl-user)
 
 (defpackage :cl-heredoc-test
   (:use :cl :cl-heredoc :stefil)


### PR DESCRIPTION
Use of this intermediary package was breaking
ASDF:MONOLITHIC-CONCATENATE-SOURCE-OP, by making it impossible to load
CL-HEREDOC without loading cl-heredoc.asd.  It is standard to just use the
CL-USER package, as is now done.

Fixes #2.